### PR TITLE
[Readme] Two Different version to be aware of

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ Credit goes to the following people for doing all the initial development on rep
 ## Ordering PCBs from JLCPCB
 
 The files needed for https://jlcpcb.com are located in the production folders:
-* `pcb/production`
+* Choose `pcb-pro/production` or `pcb/production` 
 * `thumb-pcb/production`
 
 Once uploaded, you place the order with the selected default options.  You can optionally change the solder mask color, which changes the final color of your PCB.


### PR DESCRIPTION
I ordered the wrong version lol

Might be good to update the Revision on the stencil to depict Pro vs Non pro since that is what I may be used to validate I had the correct version, but they are the same for both (Rev 2)

Additionally, wondering if GitHub releasing might be a good fit for keeping versions. Let's imagine somebody wants to update their keep board's firmware in 5-10 years, might be nice to have this in a release. 

